### PR TITLE
chore: cleanup containerfile (#235)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -20,13 +20,7 @@ ARG RECIPE=recipe.yml
 # The default image registry to write to policy.json and cosign.yaml
 ARG IMAGE_REGISTRY=ghcr.io/ublue-os
 
-
 COPY cosign.pub /usr/share/ublue-os/cosign.pub
-
-# Copy the bling from ublue-os/bling into tmp, to be installed later by the bling module
-# Feel free to remove these lines if you want to speed up image builds and don't want any bling
-COPY --from=ghcr.io/ublue-os/bling:latest /rpms /tmp/bling/rpms
-COPY --from=ghcr.io/ublue-os/bling:latest /files /tmp/bling/files
 
 # Copy build scripts & configuration
 COPY build.sh /tmp/build.sh


### PR DESCRIPTION
the /files and /rpms part of bling aren't used anymore